### PR TITLE
Support Generic Cairo `Option<T>` and `Array<T>`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,9 @@
-import {Abi, ExtractAbiFunctionName, FunctionArgs, FunctionRet} from './kanabi';
+import {Abi, ExtractAbiFunctionNames, FunctionArgs, FunctionRet} from './kanabi';
 
 export function call<
   TAbi extends Abi,
-  TFunctionName extends ExtractAbiFunctionName<TAbi>
->( 
+  TFunctionName extends ExtractAbiFunctionNames<TAbi>
+>(
   abi: TAbi,
   f: TFunctionName,
   args: FunctionArgs<TAbi, TFunctionName>

--- a/kanabi.test-d.ts
+++ b/kanabi.test-d.ts
@@ -5,7 +5,6 @@ import {
     CairoAddress,
     CairoFunction,
     CairoVoid,
-    CairoOption,
     CairoTuple,
     FunctionArgs,
     FunctionRet,
@@ -38,7 +37,6 @@ test("Cairo Types", () => {
     assertType<CairoAddress>("core::starknet::ContractAddress");
     assertType<CairoFunction>("function");
     assertType<CairoVoid>("()");
-    assertType<CairoOption>("core::option::Option<T>");
     assertType<CairoTuple>("()");
     assertType<CairoTuple>("(1)");
     assertType<CairoTuple>("(1, 2n)");
@@ -67,8 +65,6 @@ test("Cairo Types Errors", () => {
     assertType<CairoFunction>("core::integer::u8");
     // @ts-expect-error
     assertType<CairoVoid>("function");
-    // @ts-expect-error
-    assertType<CairoOption>("()");
     // @ts-expect-error
     assertType<CairoTuple>("(");
 })
@@ -212,7 +208,12 @@ test("ExtractAbiFunctionName", () => {
         | "transfer_from"
         | "approve"
         | "increase_allowance"
-        | "decrease_allowance";
+        | "decrease_allowance"
+        | "test_option"
+        | "test_array"
+        | "test_array_of_options"
+        | "test_array_of_options_of_arrays";
+
     expectTypeOf<ExtractAbiFunctionNames<TAbi>>().toEqualTypeOf<Expected>();
 })
 
@@ -225,15 +226,8 @@ test("AbiTypeToPrimitiveType", () => {
     assertType<AbiTypeToPrimitiveType<TAbi, CairoFunction>>(intValue);
     assertType<AbiTypeToPrimitiveType<TAbi, CairoVoid>>(voidValue);
 
-    // Option and Tuple aren't yet implemented, it always returns any
-    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(intValue);
-    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(bigIntValue);
-    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(voidValue);
-
+    // Tuple isn't implemented yet, it always returns any
     assertType<AbiTypeToPrimitiveType<TAbi, CairoTuple>>(intValue);
-    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(bigIntValue);
-    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(voidValue);
-
 })
 
 test("AbiTypeToPrimitiveType Errors", () => {
@@ -262,14 +256,8 @@ test("AbiParameterToPrimitiveType", () => {
     assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoFunction, name: 'x'}>>(intValue);
     assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoVoid, name: 'x'}>>(voidValue);
 
-    // Option and Tuple aren't yet implemented, it always returns any
-    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(intValue);
-    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(bigIntValue);
-    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(voidValue);
-
+    // Tuple ins't yet implemented, it always returns any
     assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoTuple, name: 'x'}>>(intValue);
-    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(bigIntValue);
-    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(voidValue);
 })
 
 test("AbiParameterToPrimitiveType Errors", () => {

--- a/kanabi.test-d.ts
+++ b/kanabi.test-d.ts
@@ -1,0 +1,58 @@
+import { FunctionArgs, FunctionRet } from "./kanabi";
+import { test, expectTypeOf, assertType } from "vitest";
+import { ABI } from "./test/example";
+
+type TAbi = typeof ABI;
+
+test("FunctionArgs", () => {
+    // inputs: felt, felt, u8, u256, ContractAddress
+    assertType<FunctionArgs<TAbi, 'constructor'>>([5n, 2n, 4, 2n, 1n]);
+
+    // inputs: []
+    assertType<FunctionArgs<TAbi, 'get_name'>>([]);
+    assertType<FunctionArgs<TAbi, 'get_symbol'>>([]);
+    assertType<FunctionArgs<TAbi, 'get_decimals'>>([]);
+    assertType<FunctionArgs<TAbi, 'get_total_supply'>>([]);
+
+    // inputs: ContractAddress
+    assertType<FunctionArgs<TAbi, 'balance_of'>>(5n);
+
+    // inputs: ContractAddress, ContractAddress, u256
+    assertType<FunctionArgs<TAbi, 'transfer_from'>>([1n, 2n, 3n]);
+
+    // inputs: ContractAddress, u256
+    assertType<FunctionArgs<TAbi, 'transfer'>>([1n, 2n]);
+    assertType<FunctionArgs<TAbi, 'approve'>>([1n, 2n]);
+    assertType<FunctionArgs<TAbi, 'increase_allowance'>>([1n, 2n]);
+    assertType<FunctionArgs<TAbi, 'decrease_allowance'>>([1n, 2n]);
+
+    // inputs: ContractAddress, ContractAddress
+    assertType<FunctionArgs<TAbi, 'allowance'>>([1n, 2n]);
+})
+
+test("FunctionRet", () => {
+    // TODO: find a way to assert a type is void
+    // output: ()
+    // assertType<FunctionRet<TAbi, 'constructor'>>();
+    // assertType<FunctionRet<TAbi, 'transfer'>>();
+    // assertType<FunctionRet<TAbi, 'approve'>>();
+    // assertType<FunctionRet<TAbi, 'increase_allowance'>>();
+    // assertType<FunctionRet<TAbi, 'decrease_allowance'>>();
+    // assertType<FunctionRet<TAbi, 'transfer_from'>>();
+
+    // output: felt
+    assertType<FunctionRet<TAbi, 'get_name'>>(10n);
+    assertType<FunctionRet<TAbi, 'get_symbol'>>(6n);
+
+    // output: u8
+    assertType<FunctionRet<TAbi, 'get_decimals'>>(1);
+
+    // output: u256
+    assertType<FunctionRet<TAbi, 'get_total_supply'>>(1n);
+
+    // inputs: u256
+    assertType<FunctionRet<TAbi, 'balance_of'>>(5n);
+
+    // output: u256
+    assertType<FunctionRet<TAbi, 'allowance'>>(50n);
+})

--- a/kanabi.test-d.ts
+++ b/kanabi.test-d.ts
@@ -1,58 +1,289 @@
-import { FunctionArgs, FunctionRet } from "./kanabi";
+import {
+    CairoFelt,
+    CairoInt,
+    CairoBigInt,
+    CairoAddress,
+    CairoFunction,
+    CairoVoid,
+    CairoOption,
+    CairoTuple,
+    FunctionArgs,
+    FunctionRet,
+    ExtractAbiFunction,
+    ExtractAbiFunctionNames,
+    AbiTypeToPrimitiveType,
+    AbiParameterToPrimitiveType,
+    ExtractAbiStruct
+} from "./kanabi";
 import { test, expectTypeOf, assertType } from "vitest";
 import { ABI } from "./test/example";
 
 type TAbi = typeof ABI;
 
+function returnVoid() { }
+
+const voidValue = returnVoid();
+const bigIntValue = 105n;
+const intValue = 10;
+const emptyArray: [] = [];
+
+test("Cairo Types", () => {
+    assertType<CairoFelt>("core::felt");
+    assertType<CairoInt>("core::integer::u8");
+    assertType<CairoInt>("core::integer::u16");
+    assertType<CairoInt>("core::integer::u32");
+    assertType<CairoBigInt>("core::integer::u64");
+    assertType<CairoBigInt>("core::integer::u128");
+    assertType<CairoBigInt>("core::integer::u256");
+    assertType<CairoAddress>("core::starknet::ContractAddress");
+    assertType<CairoFunction>("function");
+    assertType<CairoVoid>("()");
+    assertType<CairoOption>("core::option::Option<T>");
+    assertType<CairoTuple>("()");
+    assertType<CairoTuple>("(1)");
+    assertType<CairoTuple>("(1, 2n)");
+    assertType<CairoTuple>("(1, 2n, 'string')");
+    assertType<CairoTuple>("(1, 2, 3, 4, 5)");
+})
+
+test("Cairo Types Errors", () => {
+    // @ts-expect-error
+    assertType<CairoFelt>("core::integer:u8");
+    // @ts-expect-error
+    assertType<CairoInt>("core::integer::u64");
+    // @ts-expect-error
+    assertType<CairoInt>("core::integer::u128");
+    // @ts-expect-error
+    assertType<CairoInt>("core::integer::u256");
+    // @ts-expect-error
+    assertType<CairoBigInt>("core::integer::u8");
+    // @ts-expect-error
+    assertType<CairoBigInt>("core::integer::u16");
+    // @ts-expect-error
+    assertType<CairoBigInt>("core::integer::u32");
+    // @ts-expect-error
+    assertType<CairoAddress>("core::felt");
+    // @ts-expect-error
+    assertType<CairoFunction>("core::integer::u8");
+    // @ts-expect-error
+    assertType<CairoVoid>("function");
+    // @ts-expect-error
+    assertType<CairoOption>("()");
+    // @ts-expect-error
+    assertType<CairoTuple>("(");
+})
+
 test("FunctionArgs", () => {
     // inputs: felt, felt, u8, u256, ContractAddress
-    assertType<FunctionArgs<TAbi, 'constructor'>>([5n, 2n, 4, 2n, 1n]);
-
+    assertType<FunctionArgs<TAbi, 'constructor'>>(
+        [bigIntValue, bigIntValue, intValue, bigIntValue, bigIntValue]
+    );
     // inputs: []
-    assertType<FunctionArgs<TAbi, 'get_name'>>([]);
-    assertType<FunctionArgs<TAbi, 'get_symbol'>>([]);
-    assertType<FunctionArgs<TAbi, 'get_decimals'>>([]);
-    assertType<FunctionArgs<TAbi, 'get_total_supply'>>([]);
-
+    assertType<FunctionArgs<TAbi, 'get_name'>>(emptyArray);
+    assertType<FunctionArgs<TAbi, 'get_symbol'>>(emptyArray);
+    assertType<FunctionArgs<TAbi, 'get_decimals'>>(emptyArray);
+    assertType<FunctionArgs<TAbi, 'get_total_supply'>>(emptyArray);
     // inputs: ContractAddress
-    assertType<FunctionArgs<TAbi, 'balance_of'>>(5n);
-
+    assertType<FunctionArgs<TAbi, 'balance_of'>>(bigIntValue);
     // inputs: ContractAddress, ContractAddress, u256
-    assertType<FunctionArgs<TAbi, 'transfer_from'>>([1n, 2n, 3n]);
-
+    assertType<FunctionArgs<TAbi, 'transfer_from'>>([bigIntValue, bigIntValue, bigIntValue]);
     // inputs: ContractAddress, u256
-    assertType<FunctionArgs<TAbi, 'transfer'>>([1n, 2n]);
-    assertType<FunctionArgs<TAbi, 'approve'>>([1n, 2n]);
-    assertType<FunctionArgs<TAbi, 'increase_allowance'>>([1n, 2n]);
-    assertType<FunctionArgs<TAbi, 'decrease_allowance'>>([1n, 2n]);
-
+    assertType<FunctionArgs<TAbi, 'transfer'>>([bigIntValue, bigIntValue]);
+    assertType<FunctionArgs<TAbi, 'approve'>>([bigIntValue, bigIntValue]);
+    assertType<FunctionArgs<TAbi, 'increase_allowance'>>([bigIntValue, bigIntValue]);
+    assertType<FunctionArgs<TAbi, 'decrease_allowance'>>([bigIntValue, bigIntValue]);
     // inputs: ContractAddress, ContractAddress
-    assertType<FunctionArgs<TAbi, 'allowance'>>([1n, 2n]);
+    assertType<FunctionArgs<TAbi, 'allowance'>>([bigIntValue, bigIntValue]);
+})
+
+test("FunctionArgs Errors", () => {
+    // inputs: felt, felt, u8, u256, ContractAddress
+    assertType<FunctionArgs<TAbi, 'constructor'>>(
+        // @ts-expect-error constructor has 5 arguments
+        [bigIntValue, bigIntValue, intValue, bigIntValue, bigIntValue, intValue]
+    );
+    // inputs: []
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'get_name'>>(intValue);
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'get_symbol'>>(voidValue);
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'get_decimals'>>(intValue);
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'get_total_supply'>>(bigIntValue);
+    // inputs: ContractAddress
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'balance_of'>>(voidValue);
+    // inputs: ContractAddress, ContractAddress, u256
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'transfer_from'>>([bigIntValue, intValue, intValue]);
+    // inputs: ContractAddress, u256
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'transfer'>>([intValue, bigIntValue]);
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'approve'>>([bigIntValue, intValue]);
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'increase_allowance'>>([bigIntValue, voidValue]);
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'decrease_allowance'>>([bigIntValue, emptyArray]);
+    // inputs: ContractAddress, ContractAddress
+    // @ts-expect-error
+    assertType<FunctionArgs<TAbi, 'allowance'>>([intValue, intValue]);
 })
 
 test("FunctionRet", () => {
-    // TODO: find a way to assert a type is void
     // output: ()
-    // assertType<FunctionRet<TAbi, 'constructor'>>();
-    // assertType<FunctionRet<TAbi, 'transfer'>>();
-    // assertType<FunctionRet<TAbi, 'approve'>>();
-    // assertType<FunctionRet<TAbi, 'increase_allowance'>>();
-    // assertType<FunctionRet<TAbi, 'decrease_allowance'>>();
-    // assertType<FunctionRet<TAbi, 'transfer_from'>>();
-
+    assertType<FunctionRet<TAbi, 'constructor'>>(voidValue);
+    assertType<FunctionRet<TAbi, 'transfer'>>(voidValue);
+    assertType<FunctionRet<TAbi, 'approve'>>(voidValue);
+    assertType<FunctionRet<TAbi, 'increase_allowance'>>(voidValue);
+    assertType<FunctionRet<TAbi, 'decrease_allowance'>>(voidValue);
+    assertType<FunctionRet<TAbi, 'transfer_from'>>(voidValue);
     // output: felt
-    assertType<FunctionRet<TAbi, 'get_name'>>(10n);
-    assertType<FunctionRet<TAbi, 'get_symbol'>>(6n);
-
+    assertType<FunctionRet<TAbi, 'get_name'>>(bigIntValue);
+    assertType<FunctionRet<TAbi, 'get_symbol'>>(bigIntValue);
     // output: u8
-    assertType<FunctionRet<TAbi, 'get_decimals'>>(1);
-
+    assertType<FunctionRet<TAbi, 'get_decimals'>>(intValue);
     // output: u256
-    assertType<FunctionRet<TAbi, 'get_total_supply'>>(1n);
-
+    assertType<FunctionRet<TAbi, 'get_total_supply'>>(bigIntValue);
     // inputs: u256
-    assertType<FunctionRet<TAbi, 'balance_of'>>(5n);
-
+    assertType<FunctionRet<TAbi, 'balance_of'>>(bigIntValue);
     // output: u256
-    assertType<FunctionRet<TAbi, 'allowance'>>(50n);
+    assertType<FunctionRet<TAbi, 'allowance'>>(bigIntValue);
+})
+
+test("FunctionRet Errors", () => {
+    // output: ()
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'constructor'>>(intValue);
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'transfer'>>(bigIntValue);
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'approve'>>(emptyArray);
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'increase_allowance'>>(intValue);
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'decrease_allowance'>>(emptyArray);
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'transfer_from'>>(intValue);
+    // output: felt
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'get_name'>>([intValue, intValue]);
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'get_symbol'>>(voidValue);
+    // output: u8
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'get_decimals'>>(emptyArray);
+    // output: u256
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'get_total_supply'>>(intValue);
+    // inputs: u256
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'balance_of'>>([intValue, bigIntValue]);
+    // output: u256
+    // @ts-expect-error
+    assertType<FunctionRet<TAbi, 'allowance'>>([voidValue, intValue]);
+})
+
+test("ExtractAbiFunction", () => {
+    type Expected = {
+        readonly type: "function";
+        readonly name: "balance_of";
+        readonly inputs: readonly [{
+            readonly name: "account";
+            readonly ty: "core::starknet::ContractAddress";
+        }];
+        readonly output_ty: "core::integer::u256";
+        readonly state_mutability: "view";
+    };
+    expectTypeOf<ExtractAbiFunction<TAbi, "balance_of">>().toEqualTypeOf<Expected>();
+})
+
+test("ExtractAbiFunctionName", () => {
+    type Expected =
+        | "balance_of"
+        | "constructor"
+        | "get_name"
+        | "get_symbol"
+        | "get_decimals"
+        | "get_total_supply"
+        | "allowance"
+        | "transfer"
+        | "transfer_from"
+        | "approve"
+        | "increase_allowance"
+        | "decrease_allowance";
+    expectTypeOf<ExtractAbiFunctionNames<TAbi>>().toEqualTypeOf<Expected>();
+})
+
+test("AbiTypeToPrimitiveType", () => {
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoFelt>>(bigIntValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoInt>>(intValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoInt>>(bigIntValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoBigInt>>(bigIntValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoAddress>>(bigIntValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoFunction>>(intValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoVoid>>(voidValue);
+
+    // Option and Tuple aren't yet implemented, it always returns any
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(intValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(bigIntValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(voidValue);
+
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoTuple>>(intValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(bigIntValue);
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoOption>>(voidValue);
+
+})
+
+test("AbiTypeToPrimitiveType Errors", () => {
+    // @ts-expect-error CairoFelt should be bigint
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoFelt>>(intValue);
+    // @ts-expect-error CairoInt should be number or bigint
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoInt>>(voidValue);
+    // @ts-expect-error CairoBigInt should be bigint
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoBigInt>>(intValue);
+    // @ts-expect-error CairoAddress should be bigint
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoAddress>>(intValue);
+    // @ts-expect-error CairoFunction should be int
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoFunction>>(bigIntValue);
+    // @ts-expect-error CairoVoid should be void
+    assertType<AbiTypeToPrimitiveType<TAbi, CairoVoid>>(intValue);
+})
+
+test("AbiParameterToPrimitiveType", () => {
+    // TODO: add tests for struct AbiParameter
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoFelt, name: 'x'}>>(bigIntValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoFelt, name: 'x'}>>(bigIntValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoInt, name: 'x'}>>(intValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoInt, name: 'x'}>>(bigIntValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoBigInt, name: 'x'}>>(bigIntValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoAddress, name: 'x'}>>(bigIntValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoFunction, name: 'x'}>>(intValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoVoid, name: 'x'}>>(voidValue);
+
+    // Option and Tuple aren't yet implemented, it always returns any
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(intValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(bigIntValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(voidValue);
+
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoTuple, name: 'x'}>>(intValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(bigIntValue);
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoOption, name: 'x'}>>(voidValue);
+})
+
+test("AbiParameterToPrimitiveType Errors", () => {
+    // TODO: add tests for struct AbiParameter
+    // @ts-expect-error CairoFelt should be bigint
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoFelt, name: 'x'}>>(intValue);
+    // @ts-expect-error CairoInt should be number or bigint
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoInt, name: 'x'}>>(voidValue);
+    // @ts-expect-error CairoBigInt should be bigint
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoBigInt, name: 'x'}>>(intValue);
+    // @ts-expect-error CairoAddress should be bigint
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoAddress, name: 'x'}>>(intValue);
+    // @ts-expect-error CairoFunction should be int
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoFunction, name: 'x'}>>(bigIntValue);
+    // @ts-expect-error CairoVoid should be void
+    assertType<AbiParameterToPrimitiveType<TAbi, {ty: CairoVoid, name: 'x'}>>(intValue);
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,1000 @@
       "license": "ISC",
       "dependencies": {
         "typescript": "^4.9.5"
+      },
+      "devDependencies": {
+        "vitest": "^0.30.1"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
+      "integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
+      "integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
+      "integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
+      "integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
+      "integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
+      "integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
+      "integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
+      "integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
+      "integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
+      "integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
+      "integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
+      "integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
+      "integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
+      "integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
+      "integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
+      "integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
+      "integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
+      "integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
+      "integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
+      "integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
+      "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
+      "integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "dev": true
+    },
+    "node_modules/@types/chai-subset": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
+      "integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
+      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==",
+      "dev": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.30.1.tgz",
+      "integrity": "sha512-c3kbEtN8XXJSeN81iDGq29bUzSjQhjES2WR3aColsS4lPGbivwLtas4DNUe0jD9gg/FYGIteqOenfU95EFituw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "0.30.1",
+        "@vitest/utils": "0.30.1",
+        "chai": "^4.3.7"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.30.1.tgz",
+      "integrity": "sha512-W62kT/8i0TF1UBCNMRtRMOBWJKRnNyv9RrjIgdUryEe0wNpGZvvwPDLuzYdxvgSckzjp54DSpv1xUbv4BQ0qVA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "0.30.1",
+        "concordance": "^5.0.4",
+        "p-limit": "^4.0.0",
+        "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.30.1.tgz",
+      "integrity": "sha512-fJZqKrE99zo27uoZA/azgWyWbFvM1rw2APS05yB0JaLwUIg9aUtvvnBf4q7JWhEcAHmSwbrxKFgyBUga6tq9Tw==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.0",
+        "pathe": "^1.1.0",
+        "pretty-format": "^27.5.1"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.30.1.tgz",
+      "integrity": "sha512-YfJeIf37GvTZe04ZKxzJfnNNuNSmTEGnla2OdL60C8od16f3zOfv9q9K0nNii0NfjDJRt/CVN/POuY5/zTS+BA==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.1.0"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.30.1.tgz",
+      "integrity": "sha512-/c8Xv2zUVc+rnNt84QF0Y0zkfxnaGhp87K2dYJMLtLOIckPzuxLVzAtFCicGFdB4NeBHNzTRr1tNn7rCtQcWFA==",
+      "dev": true,
+      "dependencies": {
+        "concordance": "^5.0.4",
+        "loupe": "^2.3.6",
+        "pretty-format": "^27.5.1"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/blueimp-md5": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
+      "dev": true
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/concordance": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
+      "integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
+      "dev": true,
+      "dependencies": {
+        "date-time": "^3.1.0",
+        "esutils": "^2.0.3",
+        "fast-diff": "^1.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.15",
+        "md5-hex": "^3.0.1",
+        "semver": "^7.3.2",
+        "well-known-symbols": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.18.0 <11 || >=12.14.0 <13 || >=14"
+      }
+    },
+    "node_modules/date-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
+      "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
+      "dev": true,
+      "dependencies": {
+        "time-zone": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
+      "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.18",
+        "@esbuild/android-arm64": "0.17.18",
+        "@esbuild/android-x64": "0.17.18",
+        "@esbuild/darwin-arm64": "0.17.18",
+        "@esbuild/darwin-x64": "0.17.18",
+        "@esbuild/freebsd-arm64": "0.17.18",
+        "@esbuild/freebsd-x64": "0.17.18",
+        "@esbuild/linux-arm": "0.17.18",
+        "@esbuild/linux-arm64": "0.17.18",
+        "@esbuild/linux-ia32": "0.17.18",
+        "@esbuild/linux-loong64": "0.17.18",
+        "@esbuild/linux-mips64el": "0.17.18",
+        "@esbuild/linux-ppc64": "0.17.18",
+        "@esbuild/linux-riscv64": "0.17.18",
+        "@esbuild/linux-s390x": "0.17.18",
+        "@esbuild/linux-x64": "0.17.18",
+        "@esbuild/netbsd-x64": "0.17.18",
+        "@esbuild/openbsd-x64": "0.17.18",
+        "@esbuild/sunos-x64": "0.17.18",
+        "@esbuild/win32-arm64": "0.17.18",
+        "@esbuild/win32-ia32": "0.17.18",
+        "@esbuild/win32-x64": "0.17.18"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
+    "node_modules/local-pkg": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
+      "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/md5-hex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
+      "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
+      "dev": true,
+      "dependencies": {
+        "blueimp-md5": "^2.10.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
+      "integrity": "sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "pathe": "^1.1.0",
+        "pkg-types": "^1.0.2",
+        "ufo": "^1.1.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
+      "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/pkg-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.2.tgz",
+      "integrity": "sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.1.1",
+        "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/rollup": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.0.tgz",
+      "integrity": "sha512-ANPhVcyeHvYdQMUyCbczy33nbLzI7RzrBje4uvNiTDJGIMtlKoOStmympwr9OtS1LZxiDmE2wvxHyVhoLtf1KQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
+      "integrity": "sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==",
+      "dev": true
+    },
+    "node_modules/strip-literal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.1.tgz",
+      "integrity": "sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/time-zone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+      "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.4.0.tgz",
+      "integrity": "sha512-iyziEiyFxX4kyxSp+MtY1oCH/lvjH3PxFN8PGCDeqcZWAJ/i+9y+nL85w99PxVzrIvew/GSkSbDYtiGVa85Afg==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
+      "integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.0.tgz",
+      "integrity": "sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/typescript": {
@@ -22,6 +1016,205 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
+    },
+    "node_modules/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-MwFlLBO4udZXd+VBcezo3u8mC77YQk+ik+fbc0GZWGgzfbPP+8Kf0fldhARqvSYmtIWoAJ5BXPClUbMTlqFxrA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.17.5",
+        "postcss": "^8.4.23",
+        "rollup": "^3.21.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.30.1.tgz",
+      "integrity": "sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0",
+        "picocolors": "^1.0.0",
+        "vite": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": ">=v14.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.30.1.tgz",
+      "integrity": "sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^4.3.4",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "@vitest/expect": "0.30.1",
+        "@vitest/runner": "0.30.1",
+        "@vitest/snapshot": "0.30.1",
+        "@vitest/spy": "0.30.1",
+        "@vitest/utils": "0.30.1",
+        "acorn": "^8.8.2",
+        "acorn-walk": "^8.2.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.7",
+        "concordance": "^5.0.4",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.0",
+        "pathe": "^1.1.0",
+        "picocolors": "^1.0.0",
+        "source-map": "^0.6.1",
+        "std-env": "^3.3.2",
+        "strip-literal": "^1.0.1",
+        "tinybench": "^2.4.0",
+        "tinypool": "^0.4.0",
+        "vite": "^3.0.0 || ^4.0.0",
+        "vite-node": "0.30.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": ">=v14.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
+        "@vitest/ui": "*",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "playwright": "*",
+        "safaridriver": "*",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/well-known-symbols": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+      "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Abi parser for Cairo smart contracts, based on wagmi abitype",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest",
+    "coverage": "vitest run --coverage",
+    "typecheck": "vitest typecheck"
   },
   "repository": {
     "type": "git",
@@ -25,5 +27,8 @@
   },
   "dependencies": {
     "typescript": "^4.9.5"
+  },
+  "devDependencies": {
+    "vitest": "^0.30.1"
   }
 }

--- a/test/example.ts
+++ b/test/example.ts
@@ -111,6 +111,42 @@ export const ABI = [
     'state_mutability': 'external'
   },
   {
+    'type': 'function',
+    'name': 'test_option',
+    'inputs': [
+      {'name': 'option', 'ty': 'core::option::Option<core::option::Option<core::integer::u8>>'},
+    ],
+    'output_ty': '()',
+    'state_mutability': 'external'
+  },
+  {
+    'type': 'function',
+    'name': 'test_array',
+    'inputs': [
+      {'name': 'option', 'ty': 'core::array::Array::<core::integer::u8>'},
+    ],
+    'output_ty': '()',
+    'state_mutability': 'external'
+  },
+  {
+    'type': 'function',
+    'name': 'test_array_of_options',
+    'inputs': [
+      {'name': 'option', 'ty': 'core::array::Array::<core::option::Option<core::integer::u8>>'},
+    ],
+    'output_ty': '()',
+    'state_mutability': 'external'
+  },
+  {
+    'type': 'function',
+    'name': 'test_array_of_options_of_arrays',
+    'inputs': [
+      {'name': 'option', 'ty': 'core::array::Array::<core::option::Option<core::array::Array::<core::integer::u8>>>'},
+    ],
+    'output_ty': '()',
+    'state_mutability': 'external'
+  },
+  {
     'type': 'event',
     'name': 'Transfer',
     'inputs': [
@@ -129,6 +165,8 @@ export const ABI = [
     ]
   }
 ] as const;
+
+// Setting output to core::option::Option<()> causes type check errors everywhere
 
 // inputs: felt, felt, u8, u256, ContractAddress | output: ()
 const ret1 =
@@ -152,3 +190,14 @@ const ret11 = call(ABI, 'increase_allowance', [1n, 2n]);
 const ret12 = call(ABI, 'decrease_allowance', [1n, 2n]);
 // inputs: ContractAddress, ContractAddress | output: u256
 const ret7 = call(ABI, 'allowance', [1n, 2n]);
+
+const ret13 = call(ABI, 'test_option', 5);
+const ret14 = call(ABI, 'test_option', undefined);
+
+const ret15 = call(ABI, 'test_array', [1, 2, 3, 4]);
+const ret16 = call(ABI, 'test_array', [1n, 2n, 3n]);
+const ret17 = call(ABI, 'test_array', [1n, 2n, 3]);
+
+const ret18 = call(ABI, "test_array_of_options", [1, 2, undefined, undefined, 3]);
+
+const ret19 = call(ABI, "test_array_of_options_of_arrays", [[1, 2], undefined, [5, 6]])

--- a/test/example.ts
+++ b/test/example.ts
@@ -1,6 +1,6 @@
 import {call} from '../index';
 
-const ABI = [
+export const ABI = [
   {
     'type': 'function',
     'name': 'constructor',


### PR DESCRIPTION
An example contract that uses `Option<T>` and `Array<T>`
```cairo
#[contract]
mod HelloStarknet {
    use option::OptionTrait;
    use array::ArrayTrait;

    #[view]
    fn simple_array() -> Array<u8> {
        let mut a = ArrayTrait::new();

        a.append(0);
        a.append(1);
        a.append(2);

        a
    }

    #[view]
    fn simple_option() -> Option<u8> {
        Option::Some(1)
    }

    #[view]
    fn nested_option() -> Option<Option<u8>> {
        Option::Some(Option::Some(1))
    }
```