### PR TITLE
fix #42 by adding prepack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,15 @@
   "name": "abi-wan-kanabi",
   "version": "1.0.4",
   "description": "Abi parser for Cairo smart contracts, based on wagmi abitype",
-  "main": "index.js",
+  "main": "dist/index.js",
   "bin": {
     "generate": "./dist/generate.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "prepack": "tsc",
     "generate": "tsc && node dist/generate.js",
     "test": "vitest",
     "coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "tsc",
-    "generate": "tsc && node dist/generate.js",
+    "build": "tsc && cp starknet.d.ts dist/starknet.d.ts",
+    "clean": "rm -fr dist",
+    "prepack": "npm run clean && npm run build && npm run build",
+    "generate": "npm run build && node dist/generate.js",
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "typecheck": "vitest typecheck",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,12 +44,12 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                              /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "dist",                                    /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
and some tsconfig settings

this ensures the content of nmp package don't break due to consumers using different TypeScript config

fixes #42 