### PR TITLE
[Fix]: options argument for v1

### DIFF
--- a/kanabi.ts
+++ b/kanabi.ts
@@ -312,24 +312,24 @@ export type FunctionCallWithOptions<
   TAbiFunction extends AbiFunction,
 > = TAbiFunction['state_mutability'] extends 'view'
   ? (
-      options?: CallOptions,
-      ...args: ExtractArgs<TAbi, TAbiFunction>
+      ...args: [...ExtractArgs<TAbi, TAbiFunction>, CallOptions]
     ) => Promise<FunctionRet<TAbi, TAbiFunction['name']>>
   : (
-      options?: InvokeOptions,
-      ...args: ExtractArgs<TAbi, TAbiFunction>
+      ...args: [...ExtractArgs<TAbi, TAbiFunction>, InvokeOptions]
     ) => InvokeFunctionResponse
+
+export type FunctionCall<
+  TAbi extends Abi,
+  TAbiFunction extends AbiFunction,
+> = FunctionCallWithArgs<TAbi, TAbiFunction> &
+  FunctionCallWithOptions<TAbi, TAbiFunction> &
+  FunctionCallWithCallData<TAbi, TAbiFunction>
 
 export type ContractFunctions<TAbi extends Abi> = UnionToIntersection<
   {
     [K in keyof TAbi]: TAbi[K] extends infer TAbiFunction extends AbiFunction
       ? {
-          [K2 in TAbiFunction['name']]: FunctionCallWithArgs<
-            TAbi,
-            TAbiFunction
-          > &
-            FunctionCallWithCallData<TAbi, TAbiFunction> &
-            FunctionCallWithOptions<TAbi, TAbiFunction>
+          [K2 in TAbiFunction['name']]: FunctionCall<TAbi, TAbiFunction>
         }
       : never
   }[number]

--- a/test/kanabi.test-d.ts
+++ b/test/kanabi.test-d.ts
@@ -8,6 +8,7 @@ import {
   CairoTuple,
   CairoU256,
   CairoVoid,
+  ContractFunctions,
   ExtractAbiFunction,
   ExtractAbiFunctionNames,
   FunctionArgs,
@@ -24,7 +25,7 @@ function returnVoid() {}
 const voidValue = returnVoid()
 const bigIntValue = 105n
 const intValue = 10
-const stringValue = "s"
+const stringValue = 's'
 const emptyArray: [] = []
 const boolValue = true
 
@@ -289,4 +290,17 @@ test('StringToPrimitiveType Errors', () => {
   assertType<StringToPrimitiveType<TAbi, CairoFunction>>(bigIntValue)
   // @ts-expect-error CairoVoid should be void
   assertType<StringToPrimitiveType<TAbi, CairoVoid>>(intValue)
+})
+
+test('ContractFunctions', () => {
+  // @ts-expect-error
+  const contract: ContractFunctions<TAbi> = never
+
+  contract.fn_felt(1) // Call with args
+  contract.fn_felt(1, { parseRequest: true }) // Call withe invokeOptions
+  contract.fn_felt(['0x0', '0x1']) // call with CallData
+
+  contract.fn_out_simple_option()
+  contract.fn_out_simple_option({ parseResponse: true })
+  contract.fn_out_simple_option(['0x0', '0x1'])
 })


### PR DESCRIPTION
`options` argument is expected to be last in the function call by starknet.js