### PR TITLE
[Fix]: starknet.js integration for cairo 2.3.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "typescript.preferences.importModuleSpecifier": "shortest",
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.organizeImports.rome": true
+    "source.organizeImports.rome": "explicit"
   },
   "[json]": {
     "editor.defaultFormatter": "rome.rome"

--- a/kanabi.ts
+++ b/kanabi.ts
@@ -361,24 +361,25 @@ export type FunctionCallWithOptions<
   TAbiFunction extends AbiFunction,
 > = TAbiFunction['state_mutability'] extends 'view'
   ? (
-      options?: CallOptions,
-      ...args: ExtractArgs<TAbi, TAbiFunction>
+      ...args: [...ExtractArgs<TAbi, TAbiFunction>, CallOptions]
     ) => Promise<FunctionRet<TAbi, TAbiFunction['name']>>
   : (
-      options?: InvokeOptions,
-      ...args: ExtractArgs<TAbi, TAbiFunction>
+      ...args: [...ExtractArgs<TAbi, TAbiFunction>, InvokeOptions]
     ) => InvokeFunctionResponse
+
+export type FunctionCall<
+  TAbi extends Abi,
+  TAbiFunction extends AbiFunction,
+> = FunctionCallWithArgs<TAbi, TAbiFunction> &
+  FunctionCallWithCallData<TAbi, TAbiFunction> &
+  FunctionCallWithOptions<TAbi, TAbiFunction>
 
 export type ContractFunctions<TAbi extends Abi> = UnionToIntersection<
   {
-    [K in keyof TAbi]: TAbi[K] extends infer TAbiFunction extends AbiFunction
+    [K in
+      keyof ExtractAbiInterfaces<TAbi>['items']]: ExtractAbiInterfaces<TAbi>['items'][K] extends infer TAbiFunction extends AbiFunction
       ? {
-          [K2 in TAbiFunction['name']]: FunctionCallWithArgs<
-            TAbi,
-            TAbiFunction
-          > &
-            FunctionCallWithCallData<TAbi, TAbiFunction> &
-            FunctionCallWithOptions<TAbi, TAbiFunction>
+          [K2 in TAbiFunction['name']]: FunctionCall<TAbi, TAbiFunction>
         }
       : never
   }[number]

--- a/kanabi.ts
+++ b/kanabi.ts
@@ -374,13 +374,9 @@ export type FunctionCall<
   FunctionCallWithCallData<TAbi, TAbiFunction> &
   FunctionCallWithOptions<TAbi, TAbiFunction>
 
-export type ContractFunctions<TAbi extends Abi> = UnionToIntersection<
-  {
-    [K in
-      keyof ExtractAbiInterfaces<TAbi>['items']]: ExtractAbiInterfaces<TAbi>['items'][K] extends infer TAbiFunction extends AbiFunction
-      ? {
-          [K2 in TAbiFunction['name']]: FunctionCall<TAbi, TAbiFunction>
-        }
-      : never
-  }[number]
->
+export type ContractFunctions<TAbi extends Abi> = {
+  [K in ExtractAbiFunctionNames<TAbi>]: FunctionCall<
+    TAbi,
+    ExtractAbiFunction<TAbi, K>
+  >
+}

--- a/test/kanabi.test-d.ts
+++ b/test/kanabi.test-d.ts
@@ -8,13 +8,19 @@ import {
   CairoTuple,
   CairoU256,
   CairoVoid,
+  ContractFunctions,
   ExtractAbiFunction,
   ExtractAbiFunctionNames,
+  ExtractAbiFunctions,
+  ExtractAbiInterfaces,
   FunctionArgs,
+  FunctionCall,
+  FunctionCallWithArgs,
   FunctionRet,
   StringToPrimitiveType,
 } from '../kanabi'
 import { ABI } from './example'
+import { interfaces } from './interfaces'
 import { assertType, expectTypeOf, test } from 'vitest'
 
 type TAbi = typeof ABI
@@ -289,4 +295,18 @@ test('StringToPrimitiveType Errors', () => {
   assertType<StringToPrimitiveType<TAbi, CairoFunction>>(bigIntValue)
   // @ts-expect-error CairoVoid should be void
   assertType<StringToPrimitiveType<TAbi, CairoVoid>>(intValue)
+})
+
+test('ContractFunctions', () => {
+  // @ts-expect-error
+  const contract: ContractFunctions<TAbi> = never
+
+  contract.fn_felt() // Call with args
+
+  contract.fn_felt(1, { parseRequest: true }) // Call withe invokeOptions
+  contract.fn_felt(['0x0', '0x1']) // call with CallData
+
+  contract.fn_out_simple_option()
+  contract.fn_out_simple_option({ parseResponse: true })
+  contract.fn_out_simple_option(['0x0', '0x1'])
 })

--- a/test/kanabi.test-d.ts
+++ b/test/kanabi.test-d.ts
@@ -1,3 +1,4 @@
+import { TypedContract } from '..'
 import {
   AbiTypeToPrimitiveType,
   CairoAddress,
@@ -8,19 +9,13 @@ import {
   CairoTuple,
   CairoU256,
   CairoVoid,
-  ContractFunctions,
   ExtractAbiFunction,
   ExtractAbiFunctionNames,
-  ExtractAbiFunctions,
-  ExtractAbiInterfaces,
   FunctionArgs,
-  FunctionCall,
-  FunctionCallWithArgs,
   FunctionRet,
   StringToPrimitiveType,
 } from '../kanabi'
 import { ABI } from './example'
-import { interfaces } from './interfaces'
 import { assertType, expectTypeOf, test } from 'vitest'
 
 type TAbi = typeof ABI
@@ -299,12 +294,17 @@ test('StringToPrimitiveType Errors', () => {
 
 test('ContractFunctions', () => {
   // @ts-expect-error
-  const contract: ContractFunctions<TAbi> = never
+  const contract: TypedContract<TAbi> = never
 
-  contract.fn_felt() // Call with args
-
+  contract.fn_felt(1) // Call with args
   contract.fn_felt(1, { parseRequest: true }) // Call withe invokeOptions
   contract.fn_felt(['0x0', '0x1']) // call with CallData
+
+  // @ts-expect-error fn_felt argument should be BigNumberish (string | number | bigint)
+  contract.fn_felt(true)
+
+  // @ts-expect-error
+  contract.fn_felt(1, { wrong_call_option: true })
 
   contract.fn_out_simple_option()
   contract.fn_out_simple_option({ parseResponse: true })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,10 +8,12 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
-    "target": "ES2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ES2020", "ESNext"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "ES2020", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [
+      "ES2020",
+      "ESNext"
+    ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -23,9 +24,8 @@
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs", /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -37,12 +37,10 @@
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
@@ -67,16 +65,14 @@
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -95,12 +91,11 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
-
+    "skipLibCheck": true, /* Skip type checking all .d.ts files. */
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "noErrorTruncation": true,
   }
 }


### PR DESCRIPTION
The previous implementation of ContractFunctions type was broken for cairo 2.3.0, I had to rework it to be compatbile with the new ABI changes introduced in 2.3.0