### PR TITLE
Fix generate

### DIFF
--- a/generate.ts
+++ b/generate.ts
@@ -21,8 +21,14 @@ const argv = yargs
 
 async function run() {
   const json: { abi: object } = await fs.readJson(argv.input)
+  let abi = json.abi
+
+  if (typeof abi === 'string') {
+    abi = JSON.parse(abi)
+  }
+
   const content = `export const ABI = ${JSON.stringify(
-    json.abi,
+    abi,
     null,
     2,
   )} as const;\n`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
- set the outDir to `./dist`
- The ABI returned from `starkli` is, sometimes, embedded inside a string