### PR TITLE
Fix type exports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-export { Config, DefaultConfig, ResolvedConfig } from './config'
+export type { Config, DefaultConfig, ResolvedConfig } from './config'
 import {
   Abi,
   Call,


### PR DESCRIPTION
when building a vite app, the following error occurs:
```
$ tsc && vite build
node_modules/abi-wan-kanabi-v2/index.ts:1:10 - error TS1205: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.

1 export { Config, DefaultConfig, ResolvedConfig } from './config'
           ~~~~~~

node_modules/abi-wan-kanabi-v2/index.ts:1:18 - error TS1205: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.

1 export { Config, DefaultConfig, ResolvedConfig } from './config'
                   ~~~~~~~~~~~~~

node_modules/abi-wan-kanabi-v2/index.ts:1:33 - error TS1205: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.

1 export { Config, DefaultConfig, ResolvedConfig } from './config'
                                  ~~~~~~~~~~~~~~


Found 3 errors in the same file, starting at: node_modules/abi-wan-kanabi-v2/index.ts:1

error Command failed with exit code 2.
```