### PR TITLE
feat: export internal helper types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abi-wan-kanabi",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Abi parser for Cairo smart contracts, based on wagmi abitype",
   "main": "./dist/index.js",
   "bin": {
@@ -22,6 +22,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./kanabi": {
+      "types": "./dist/kanabi.d.ts",
+      "import": "./dist/kanabi.js",
+      "default": "./dist/kanabi.js"
     }
   },
   "repository": {


### PR DESCRIPTION
We need the internal helper types in Starknet React. Until now we were
importing them from `abi-wan-kanabi/dist/kanabi` but it doesn't work in some
setups.

This PR adds a new module so that they can be imported from `abi-wan-kanabi/kanabi`.
It's a non-breaking change.
